### PR TITLE
Improve user build experience 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,6 @@ set(HEADERS
   )
 
 # add the executable
-add_executable(kff_example main.cpp ${SRCS} ${HEADERS})
+add_executable(kff_example main.cpp ${SRCS})
 
-add_library(kff ${SRCS} ${HEADERS})
+add_library(kff ${SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 # set(CMAKE_BUILD_TYPE Debug)
 
+include_directories(${CMAKE_BINARY_DIR})
+
 set(CMAKE_CXX_FLAGS "-Wall")
 
 set(SRCS


### PR DESCRIPTION
Hi,

This PR try to improve user build experience.

I remove a warning message for user with cmake upper than 3.20.5

And now user can build project with pipeline similar to this one:
```
mkdir foo_bar
cd foo_bar
cmake ..
make
```