### PR TITLE
Better error message when the file does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ kff_example
 **/CMakeFiles/
 **/Makefile
 **/*.cmake
+build
 
 # aspell files
 **/*.bak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16)
 # set the project name
 project(KFF)
 project(KFF VERSION 1.0)
-configure_file(${PROJECT_SOURCE_DIR}/kff_io.hpp.in ${PROJECT_SOURCE_DIR}/kff_io.hpp)
+configure_file(${PROJECT_SOURCE_DIR}/kff_io.hpp.in ${CMAKE_BINARY_DIR}/kff_io.hpp)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 14)

--- a/kff_io.cpp
+++ b/kff_io.cpp
@@ -704,7 +704,7 @@ Section * SectionBuilder::build(Kff_file * file) {
 			return new Section_Minimizer(file);
 		default:
 			cerr << "Unknown section " << type << "(" << (uint)type << ")" << endl;
-			throw std::runtime_error("Unknown section type" + type);
+			throw std::runtime_error("Unknown section type " + std::string(1, type));
 	}
 }
 

--- a/kff_io.cpp
+++ b/kff_io.cpp
@@ -79,6 +79,10 @@ void Kff_file::open(string mode) {
 		if (this->file_size == 0 and this->next_free == 0) {
 			// Open the fp
 			this->fs.open(this->filename, fstream::binary | fstream::in);
+			if (this->fs.fail()) {
+				std::string msg = "Cannot open file " + this->filename;
+				throw std::runtime_error(msg);
+			}
 			// Compute the file length
 			long position = this->fs.tellp();
 			this->fs.seekg(0, this->fs.end);


### PR DESCRIPTION
Currently if you try opening a nonexistent KFF file for reading, you get an error message like:

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  Read out of the file, Byte 0
```

This PR adds a more informative error message `Cannot open file <filename>`.