### PR TITLE
Add cstdint include needed for gcc 13.2

### DIFF
--- a/kff_io.cpp
+++ b/kff_io.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <cstring>
 #include <sstream>
+#include <cstdint>
 #include <math.h>
 
 #include <map>

--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 #include <cstring>
+#include <cstdint>
 #include <map>
 
 #include "kff_io.hpp"


### PR DESCRIPTION
This project won't build on Ubuntu 22.04.1 / GCC 13.2 due tons of errors of the form:

>/home/hickey/dev/kff-cpp-api/main.cpp:202:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/hickey/dev/kff-cpp-api/main.cpp:216:6: error: variable or field ‘uint8_unpacking’ declared void
  216 | void uint8_unpacking(uint8_t packed, char * decoded, size_t size);

This PR resolves this by adding the missing `<cstdint>` include. 